### PR TITLE
Add the iPA code to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -42,6 +42,8 @@ localisation:
     - en
 it:
   countryExtensionVersion: '0.2'
+  riuso:
+    codiceIPA: ingv
 description:
   en:
     genericName: fdsnws-fetcher


### PR DESCRIPTION
The software catalog of Developers Italia uses the `codiceIPA` field to distinguish between software published by the Public Administration and third-party open source software, so in this case we should include it.